### PR TITLE
Adjustments to handle separate SAST and SCA scans

### DIFF
--- a/.gitlab-ci.yaml
+++ b/.gitlab-ci.yaml
@@ -27,26 +27,54 @@ scan-job:
   # Upload IRX file to ASoC to be analyzed and receive scanId
   - appscan.sh queue_analysis -a $appID >> output.txt
   - cat output.txt
-  - scanId=$(sed -n '2p' output.txt)
-  # Check scanId for scan status to be Ready
+  # Separate SAST and SCA scan IDs
+  - scanIdSCA=$(sed -n '3p' output.txt)
+  - scanIdSAST=$(sed -n '5p' output.txt)
+
+  # Wait for both SCA and SAST scans to be Ready
   - >
     for x in $(seq 1 1000)
       do
-        resultScan=$(appscan.sh status -i $scanId)
-        echo $resultScan 
-        if [ "$resultScan" == "Ready" ]
-          then break 
+        resultScanSAST=$(appscan.sh status -i $scanIdSAST)
+        resultScanSCA=$(appscan.sh status -i $scanIdSCA)
+        echo "SAST Status: $resultScanSAST"
+        echo "SCA Status: $resultScanSCA"
+
+        if [ "$resultScanSAST" == "Ready" ] && [ "$resultScanSCA" == "Ready" ]
+        then
+          echo "Both scans are ready."
+          break
         fi
         sleep 60
       done
-  # Get report from ASoC
-  - appscan.sh get_result -i $scanId -t html
-  # Get scan summary and determine if 
-  - appscan.sh info -i $scanId > scanStatus.txt
-  - highIssues=$(cat scanStatus.txt | grep LatestExecution | grep -oP '(?<="NHighIssues":)[^,]*')
-  - mediumIssues=$(cat scanStatus.txt | grep LatestExecution | grep -oP '(?<="NMediumIssues":)[^,]*')
-  - lowIssues=$(cat scanStatus.txt | grep LatestExecution | grep -oP '(?<="NLowIssues":)[^,]*')
-  - totalIssues=$(cat scanStatus.txt | grep LatestExecution | grep -oP '(?<="NIssuesFound":)[^,]*')
+
+  # Get report from ASoC for both scans (SCA and SAST)
+  - appscan.sh get_result -i $scanIdSCA -t html -d ./SCA_Report.html
+  - appscan.sh get_result -i $scanIdSAST -t html -d ./SAST_Report.html
+
+  # Get scan summary for both SCA and SAST
+  - appscan.sh info -i $scanIdSCA > scanStatusSCA.txt
+  - appscan.sh info -i $scanIdSAST > scanStatusSAST.txt
+
+  # Extract issue counts for SCA
+  - highIssuesSCA=$(cat scanStatusSCA.txt | grep LatestExecution | grep -oP '(?<="NHighIssues":)[^,]*')
+  - mediumIssuesSCA=$(cat scanStatusSCA.txt | grep LatestExecution | grep -oP '(?<="NMediumIssues":)[^,]*')
+  - lowIssuesSCA=$(cat scanStatusSCA.txt | grep LatestExecution | grep -oP '(?<="NLowIssues":)[^,]*')
+  - totalIssuesSCA=$(cat scanStatusSCA.txt | grep LatestExecution | grep -oP '(?<="NIssuesFound":)[^,]*')
+
+  # Extract issue counts for SAST
+  - highIssuesSAST=$(cat scanStatusSAST.txt | grep LatestExecution | grep -oP '(?<="NHighIssues":)[^,]*')
+  - mediumIssuesSAST=$(cat scanStatusSAST.txt | grep LatestExecution | grep -oP '(?<="NMediumIssues":)[^,]*')
+  - lowIssuesSAST=$(cat scanStatusSAST.txt | grep LatestExecution | grep -oP '(?<="NLowIssues":)[^,]*')
+  - totalIssuesSAST=$(cat scanStatusSAST.txt | grep LatestExecution | grep -oP '(?<="NIssuesFound":)[^,]*')
+
+  # Combine issues from both scans
+  - highIssues=$(($highIssuesSCA + $highIssuesSAST))
+  - mediumIssues=$(($mediumIssuesSCA + $mediumIssuesSAST))
+  - lowIssues=$(($lowIssuesSCA + $lowIssuesSAST))
+  - totalIssues=$(($totalIssuesSCA + $totalIssuesSAST))
+  - echo "Total issues -> $totalIssues"
+  # Determine if the scan passes or fails based on the combined issues
   - >
     if [ "$highIssues" -gt "$maxIssuesAllowed" ] && [ "$sevSecGw" == "highIssues" ]
       then
@@ -80,4 +108,5 @@ scan-job:
   artifacts:
     when: always
     paths:
-      - "*.html"
+      - "SCA_Report.html"
+      - "SAST_Report.html"


### PR DESCRIPTION
Hi, 
I noticed that in the latest SA Client update the SAST and SCA scans have been separated and therefore two separate reports are generated per scan type. As you can see, running the `queue_analysis` command now produces a result like this:

`$ appscan.sh queue_analysis -a $appID >> output.txt
$ cat output.txt
100% transferred
SCA scan ID: 
2ec88149-6bdd-467c-ba14-269fcd8ca461
SAST scan ID: 
c143f2e0-1daa-40cc-80dc-9d8d57c69311`

I have asked your support team for details about this change and have been told that it is preferable to separate the two reports and that this change will not be reversible. Based on this, I updated the code to save both reports as artifacts and now issue calculation is done on sum of both reports to get same result as before.